### PR TITLE
Wp 65 - A11y optimalisaties level level

### DIFF
--- a/src/components/SearchDetail.vue
+++ b/src/components/SearchDetail.vue
@@ -9,10 +9,10 @@
     <div v-if="searchState.wasSearched" class="search-body">
       <div class="search-filters">
         <div class="search-filters-head">
-          <h4 class="search-filter-title">
+          <div class="search-filter-title">
             {{ translate("filter")
             }}<span class="mobile-only"> {{ translate("andSort") }}</span>
-          </h4>
+          </div>
           <span class="mobile-only" @click="toggleFilters"
             ><svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
               <path

--- a/src/components/SearchDetail.vue
+++ b/src/components/SearchDetail.vue
@@ -13,7 +13,11 @@
             {{ translate("filter")
             }}<span class="mobile-only"> {{ translate("andSort") }}</span>
           </div>
-          <span class="mobile-only" @click="toggleFilters"
+          <span
+            class="mobile-only"
+            @click="toggleFilters"
+            tabindex="0"
+            @keyup.space="toggleFilters"
             ><svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M9.467 7.878l6.025-5.893a.849.849 0 000-1.22L14.966.25a.892.892 0 00-.623-.25.883.883 0 00-.622.253L7.877 5.965 2.038.253A.883.883 0 001.416 0a.883.883 0 00-.623.253l-.53.514a.85.85 0 000 1.218L6.28 7.87.258 13.765a.849.849 0 000 1.22l.527.515c.165.16.388.25.622.25.236 0 .458-.09.623-.252l5.842-5.713 5.84 5.713a.883.883 0 00.623.252c.235 0 .457-.09.622-.252l.528-.515a.85.85 0 000-1.218L9.467 7.877z"
@@ -238,6 +242,10 @@ export default {
 
     toggleFilters() {
       this.$refs.searchFilters.classList.toggle("show-filters");
+
+      if (this.$refs.searchFilters.classList.contains("show-filters")) {
+        document.querySelector(".search-filters-head > .mobile-only").focus();
+      }
     },
   },
   mixins: [getTranslations],

--- a/src/components/SearchHeader.vue
+++ b/src/components/SearchHeader.vue
@@ -4,7 +4,6 @@
       v-model="searchInputValue"
       @submit="handleFormSubmit"
       @keyUpEvent="handleFlyOutEvent"
-      @clear="clearFlyOut"
       @show="showFlyOut"
       :class="pageType"
     />
@@ -85,12 +84,27 @@ export default {
       this.driver.setSort(newSortBy, "asc");
     },
   },
+  beforeMount() {
+    document.querySelector("body").addEventListener("click", this.hideFlyout);
+    document.querySelector("body").addEventListener("keydown", this.hideFlyout);
+  },
   mounted() {
     if (window.location.search.includes("q=")) {
       this.setupSearchDriver();
     }
   },
   methods: {
+    hideFlyout(event) {
+      const isResultFlyout = event.path.some((item) =>
+        ["results-flyout-wrapper", "search-box"].includes(item.className)
+      );
+
+      if (!isResultFlyout) {
+        if (this.pageType === "flyout") {
+          this.pageType = null;
+        }
+      }
+    },
     setupSearchDriver() {
       this.driver = new SearchDriver(config(this.env, this.language));
       this.driver.setResultsPerPage(10);

--- a/src/components/elements/SearchBar.vue
+++ b/src/components/elements/SearchBar.vue
@@ -9,7 +9,6 @@
             class="search-box text-input"
             :class="{ 'search-box-warning': warningClass }"
             :value="value"
-            @blur="$emit('clear')"
             @focus="$emit('show', $event.target.value)"
             @input="$emit('input', $event.target.value)"
           />

--- a/src/components/elements/SearchFacet.vue
+++ b/src/components/elements/SearchFacet.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-show="facet.data.length" class="search-facets">
-    <h5 class="facets-title">
+    <div class="facets-title">
       {{ translate(facet.field) }}
-    </h5>
+    </div>
     <div
       class="facet"
       v-for="facetItem in facet.data"
@@ -15,7 +15,10 @@
         :id="getValue(facetItem, facet.type)"
         :value="getValue(facetItem, facet.type)"
         :checked="isChecked(getValue(facetItem, facet.type))"
-        @change="$emit('change', $event)"
+        @change="
+          $emit('change', $event);
+          $event.target.blur();
+        "
       />
       <label :for="getValue(facetItem, facet.type)" class="search-facets-label">
         {{ translate(getValue(facetItem, facet.type)) }}
@@ -70,6 +73,7 @@ export default {
   align-items: center;
   width: 100%;
   line-height: 1.8;
+  cursor: pointer;
 
   label {
     flex-grow: 1;
@@ -82,7 +86,6 @@ export default {
 }
 
 .search-facets-checkbox {
-  display: none;
   appearance: none;
 
   & + .search-facets-label {
@@ -116,6 +119,11 @@ export default {
       background: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="%233fa9f6" d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>');
       background-size: 18px;
     }
+  }
+
+  &:focus + .search-facets-label,
+  &:hover + .search-facets-label {
+    text-decoration: underline;
   }
 
   &:checked + .search-facets-label:before {

--- a/src/components/elements/SearchPagingInfoFlyout.vue
+++ b/src/components/elements/SearchPagingInfoFlyout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="search-results-summary">
+  <div class="search-results-summary" aria-live="polite">
     {{ searchState.totalResults }} {{ translate("resultsCounter") }} "{{
       searchState.searchTerm
     }}"

--- a/src/components/elements/SearchResult.vue
+++ b/src/components/elements/SearchResult.vue
@@ -1,8 +1,10 @@
 <template>
-  <article
+  <a
+    href="#"
     class="search-result"
     :class="{ 'out-of-stock': outOfStock }"
     @click="followLink"
+    :aria-label="result.title.raw || ''"
   >
     <div v-if="result.image_url" class="image">
       <img :src="result.image_url.raw" alt="" />
@@ -185,7 +187,7 @@
     </div>
     <div class="search-result-body">
       <div class="search-result-heading">
-        <h2 class="search-result-title">
+        <h3 class="search-result-title">
           <template v-if="result.title">{{ result.title.raw }}</template>
           <span v-if="result.type">{{ translate(result.type.raw) }}</span>
           <span v-if="externalHost"
@@ -194,7 +196,7 @@
                 d="M8.33 55.82h41.24v-2l.17-14.43c.1-2.66 1.76-3.98 4.2-3.85 1.95.1 3.44 1.83 3.53 4.17l.01 4.2-.02 12.52c-.06 4.42-3 7.33-7.4 7.33H7.78c-4.35-.01-7.33-3-7.34-7.4V14.1c.01-4.3 2.9-7.28 7.23-7.33l16.74-.01c2.57.02 4.26 1.63 4.26 3.92 0 2.28-1.7 3.92-4.25 3.95l-16.1.01v41.2zM56.4 13.48l-1.56 1.47-20 20c-1.1 1.1-2.25 1.74-3.9 1.45-2.97-.52-4.32-3.78-2.48-6.18.33-.43.73-.8 1.12-1.18l21.2-21.2-6.62-.05c-1.57 0-3.14.05-4.7-.02-2.32-.1-3.9-1.77-3.9-3.96.01-2.18 1.63-3.85 3.96-3.86l18.04.02C61.3.05 64.17 3 64.22 6.8l.01 17.88c-.02 2.34-1.66 3.95-3.84 4-2.23.03-3.95-1.64-4-4.03l-.01-11.16z"
               /></svg
           ></span>
-        </h2>
+        </h3>
         <span
           v-if="result.price"
           v-html="result.price.raw"
@@ -212,7 +214,7 @@
         >{{ translate("outOfStock") }}</span
       >
     </div>
-  </article>
+  </a>
 </template>
 
 <script>
@@ -238,7 +240,9 @@ export default {
     },
   },
   methods: {
-    followLink() {
+    followLink(event) {
+      event.preventDefault();
+
       this.driver.trackClickThrough(this.result.id.raw);
 
       if (this.result.url.raw) {
@@ -264,6 +268,7 @@ export default {
   @extend %flex;
 
   border-bottom: 1px solid $color-border-default;
+  text-decoration: none;
   cursor: pointer;
 
   &:hover {
@@ -307,6 +312,7 @@ export default {
       font-size: 15px;
       font-weight: 400;
       margin: 0;
+      color: $color-primary;
 
       span {
         @extend %padding-left-tiny;
@@ -364,6 +370,7 @@ export default {
   }
 
   .search-description {
+    color: $color-global-dark;
     font-size: 15px;
     height: 52px; // fallback for IE
     overflow: hidden;


### PR DESCRIPTION
Dit is er allemaal op verzoek van LevelLevel aangepast:

**Zoeken header component**

- Zoekresultaten zijn niet focusbaar ( a href of button mist? )
- aria-label toevoegen op zoekresultaat voor uitleg van de link

**Zoekresultaten detail
Sidebar:**

- H4 filter -> p of div van maken
- H5 type -> p of div van maken
- Filter checkboxes zijn niet focusbaar met de tab toets ( display: none )

**Zoekresultaten**

- H2.search-result-title -> h3 van maken
- Zoekresultaten zijn niet focusbaar ( a href of button mist )
- Geen <article> element gebruiken voor een zoekresultaat
- Aria-label toevoegen op zoekresultaat voor uitleg van de link
- De filter modal op mobile is niet focusbaar, de focus moet in deze modal blijven tot dat deze gesloten wordt door de gebruiker
- Div met aria-live=“polite” property toevoegen om aan te geven hoeveel resultaten er gevonden zijn met de zoektermen