### PR TITLE
Updated locales in translation file to language instead of country

### DIFF
--- a/src/translations/translations.json
+++ b/src/translations/translations.json
@@ -76,7 +76,7 @@
       "leaflet": "Notice",
       "faq": "FAQ"
     },
-    "se": {
+    "sv": {
       "searchPlaceholder": "Sök efter produkter, symtom eller ställ en fråga ...",
       "showAll": "Visa allt",
       "resultsCounterInfix": "från",
@@ -133,7 +133,7 @@
       "leaflet": "Folheto informativo",
       "faq": "Perguntas frequentes"
     },
-    "dk": {
+    "da": {
       "searchPlaceholder": "Søg efter produkter, symptomer eller stil et spørgsmål ...",
       "showAll": "Vis alt",
       "resultsCounterInfix": "-",


### PR DESCRIPTION
In WP is de language geïmplementeerd dus dit moet hiervoor al aangepast worden. Oude DOK hanteert ook de language en de nieuwe talen voor de search moeten ook al in het oude dok live.