### PR TITLE
[DV-1427] Added support for keycode 229 android keyboard

### DIFF
--- a/src/components/elements/SearchBar.vue
+++ b/src/components/elements/SearchBar.vue
@@ -80,7 +80,7 @@ export default {
       if (
         (keyCode >= 48 && keyCode <= 57) ||
         (keyCode >= 65 && keyCode <= 91) ||
-        [8, 189].includes(keyCode)
+        [8, 189, 229].includes(keyCode)
       ) {
         return true;
       }


### PR DESCRIPTION
Probleem gevonden!
Als je het Android keyboard in Browserstack gebruikt kan je het probleem reproduceren.

Om dit te testen kan je local Browserstack gebruiken


